### PR TITLE
Explicitly require PHP 5.6 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         ]
     },
     "require": {
+        "php": ">=5.6",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^1.19",


### PR DESCRIPTION
Just in `composer.json`. We don't test on anything under 5.6