### PR TITLE
Disable eCommerce if installing via a tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The recommended way to install Presto is to use our [Composer project scaffoldin
 composer create-project sitback/presto-project MYPROJECT --stability dev --no-interaction
 ```
 
+You can also [download a pre-packaged tarball off drupal.org](https://www.drupal.org/project/presto), however, due to limitations of the drupal.org packager, **installing eCommerce is not supported in this installation method**.
+
 ## Included in Presto
 
 ~~You can demo most of the below functionality on our demo site~~ (coming soon!)

--- a/src/Installer/Form/PrestoConfigureForm.php
+++ b/src/Installer/Form/PrestoConfigureForm.php
@@ -57,6 +57,7 @@ class PrestoConfigureForm extends FormBase {
       '#description' => $this->t(
         'Enables Drupal Commerce and some sane defaults to help you kickstart your eCommerce site.'
       ),
+      '#disabled' => !$enableCommerce,
       '#default_value' => $enableCommerce,
     ];
 
@@ -66,6 +67,7 @@ class PrestoConfigureForm extends FormBase {
       '#description' => $this->t(
         'Creates a few demo products to help you test your new eCommerce site.'
       ),
+      '#disabled' => !$enableCommerce,
       '#default_value' => $enableCommerce,
       '#states' => [
         'visible' => [

--- a/src/Installer/Form/PrestoConfigureForm.php
+++ b/src/Installer/Form/PrestoConfigureForm.php
@@ -34,13 +34,30 @@ class PrestoConfigureForm extends FormBase {
       '#collapsible' => FALSE,
     ];
 
+    // Only enable commerce if this profile was installed via Composer
+    // (which is when the below interface will exist).
+    $enableCommerce = FALSE;
+    if (interface_exists('CommerceGuys\Intl\Currency\CurrencyInterface')) {
+      $enableCommerce = TRUE;
+    }
+
+    if (!$enableCommerce) {
+      $disabledMsg = $this->t('Unfortunately, eCommerce is only supported if you install Presto! via Composer due to packaging limitations on drupal.org. <a href=":url">See the README for more information on installing via Composer.</a>', [
+        ':url' => 'https://github.com/Sitback/presto#installing-presto',
+      ]);
+      $form['ecommerce']['disabled_info'] = [
+        '#type' => 'markup',
+        '#markup' => $disabledMsg,
+      ];
+    }
+
     $form['ecommerce']['enable_ecommerce'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable eCommerce'),
       '#description' => $this->t(
         'Enables Drupal Commerce and some sane defaults to help you kickstart your eCommerce site.'
       ),
-      '#default_value' => TRUE,
+      '#default_value' => $enableCommerce,
     ];
 
     $form['ecommerce']['ecommerce_install_demo_content'] = [
@@ -49,7 +66,7 @@ class PrestoConfigureForm extends FormBase {
       '#description' => $this->t(
         'Creates a few demo products to help you test your new eCommerce site.'
       ),
-      '#default_value' => TRUE,
+      '#default_value' => $enableCommerce,
       '#states' => [
         'visible' => [
           'input[name="enable_ecommerce"]' => [

--- a/src/Installer/Form/PrestoConfigureForm.php
+++ b/src/Installer/Form/PrestoConfigureForm.php
@@ -42,7 +42,7 @@ class PrestoConfigureForm extends FormBase {
     }
 
     if (!$enableCommerce) {
-      $disabledMsg = $this->t('Unfortunately, eCommerce is only supported if you install Presto! via Composer due to packaging limitations on drupal.org. <a href=":url">See the README for more information on installing via Composer.</a>', [
+      $disabledMsg = $this->t('<p><strong>Not supported.</strong></p><p>Unfortunately, eCommerce is only supported if you install Presto via Composer. <a href=":url">See the README for more information on installing via Composer.</a></p>', [
         ':url' => 'https://github.com/Sitback/presto#installing-presto',
       ]);
       $form['ecommerce']['disabled_info'] = [


### PR DESCRIPTION
We can't add things into Drupal's `vendor` folder via the `.make` file (which all drupal.org uses to build the tarball). Commerce depends on a few external libraries, e.g. `commerceguys/intl`.

The only way to fix the installation issue is to disable eCommerce if installing via the tarball.