### PR TITLE
Add provisional PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_install:
   - composer --version
 
 install:
-  - echo $PHP_VERSION
-  - composer --verbose install
+  - if [[ $PHP_VERSION = 55 ]]; then composer --verbose install --no-dev; fi;
+  - if [[ $PHP_VERSION != 55 ]]; then composer --verbose install; fi;
 
 script:
   - if [[ $RELEASE = dev ]]; then composer --verbose update; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   global:
     - SIMPLETEST_DB=sqlite://tmp/site.sqlite
     - SIMPLETEST_BASE_URL="http://127.0.0.1:8080"
+    - PHP_VERSION=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
 
 before_install:
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -24,6 +25,7 @@ before_install:
   - composer --version
 
 install:
+  - echo $PHP_VERSION
   - composer --verbose install
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         ]
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.5",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "oomphinc/composer-installers-extender": "^1.1",

--- a/src/Installer/Ecommerce/Installer.php
+++ b/src/Installer/Ecommerce/Installer.php
@@ -15,8 +15,12 @@ class Installer {
   const DEPENDENCY_TYPE_MODULE = 'module';
   const DEPENDENCY_TYPE_THEME = 'theme';
 
-  // All eCommerce dependencies.
-  const REQUIRED_DEPENDENCIES = [
+  /**
+   * All eCommerce dependencies.
+   *
+   * @var array
+   */
+  private $dependencies = [
     'commerce' => self::DEPENDENCY_TYPE_MODULE,
     'commerce_order' => self::DEPENDENCY_TYPE_MODULE,
     'commerce_price' => self::DEPENDENCY_TYPE_MODULE,
@@ -128,7 +132,7 @@ class Installer {
   private function addDependencyOperations() {
     $operations = [];
 
-    foreach (static::REQUIRED_DEPENDENCIES as $module => $type) {
+    foreach ($this->dependencies as $module => $type) {
       $operations[] = [
         [static::class, 'installDependency'],
         [


### PR DESCRIPTION
It won't officially be recommended by us but a few services, e.g. [simplytest.me](simplytest.me) only support PHP 5.5.
