### PR TITLE
Add (provisional) PHP5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         ]
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.5",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "oomphinc/composer-installers-extender": "^1.1",

--- a/src/Installer/Ecommerce/Installer.php
+++ b/src/Installer/Ecommerce/Installer.php
@@ -15,8 +15,12 @@ class Installer {
   const DEPENDENCY_TYPE_MODULE = 'module';
   const DEPENDENCY_TYPE_THEME = 'theme';
 
-  // All eCommerce dependencies.
-  const REQUIRED_DEPENDENCIES = [
+  /**
+   * All eCommerce dependencies.
+   *
+   * @var array
+   */
+  private $dependencies = [
     'commerce' => self::DEPENDENCY_TYPE_MODULE,
     'commerce_order' => self::DEPENDENCY_TYPE_MODULE,
     'commerce_price' => self::DEPENDENCY_TYPE_MODULE,
@@ -128,7 +132,7 @@ class Installer {
   private function addDependencyOperations() {
     $operations = [];
 
-    foreach (static::REQUIRED_DEPENDENCIES as $module => $type) {
+    foreach ($this->dependencies as $module => $type) {
       $operations[] = [
         [static::class, 'installDependency'],
         [


### PR DESCRIPTION
It won't officially be recommended by us but a few services, e.g. [simplytest.me](simplytest.me) only support PHP 5.5.