### PR TITLE
Fix non-composer install

### DIFF
--- a/presto.info.yml
+++ b/presto.info.yml
@@ -56,7 +56,6 @@ dependencies:
   - redirect
   - slick
   - slick_media
-  - swiftmailer
   - social_media
   - simple_sitemap
   - token

--- a/presto.install
+++ b/presto.install
@@ -8,11 +8,11 @@
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
+use Drupal\presto\Form\PrestoConfigureForm;
+use Drupal\presto\Installer\Ecommerce\Installer as EcommerceInstaller;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
-use Drupal\presto\Installer\Form\PrestoConfigureForm;
-use Drupal\presto\Installer\Ecommerce\Installer as EcommerceInstaller;
 
 /**
  * Implements hook_install_tasks().

--- a/presto.install
+++ b/presto.install
@@ -9,7 +9,7 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\presto\Form\PrestoConfigureForm;
-use Drupal\presto\Installer\Ecommerce\Installer as EcommerceInstaller;
+use Drupal\presto\Installer\Ecommerce\EcommerceInstaller;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
@@ -136,7 +136,9 @@ function presto_apply_configuration(array &$install_state) {
     'operations' => [],
   ];
 
-  $ecommerceInstaller = EcommerceInstaller::create((array)$install_state);
+  /** @var Drupal\presto\Installer\Ecommerce\EcommerceInstaller $ecommerceInstaller */
+  $ecommerceInstaller = Drupal::service('presto.installer.ecommerce');
+  $ecommerceInstaller->setInstallState((array) $install_state);
   // Install modules and create demo content if eCommerce is enabled.
   $batch['operations'] = array_merge(
     $batch['operations'],

--- a/presto.install
+++ b/presto.install
@@ -136,10 +136,19 @@ function presto_apply_configuration(array &$install_state) {
     'operations' => [],
   ];
 
-  /** @var Drupal\presto\Installer\Ecommerce\EcommerceInstaller $ecommerceInstaller */
+  // Install optional dependencies if they're enabled.
+  /** @var \Drupal\presto\Installer\InstallerInterface $optionalDepsInstaller */
+  $optionalDepsInstaller = Drupal::service('presto.install.optional_dependencies');
+  $optionalDepsInstaller->setInstallState((array) $install_state);
+  $batch['operations'] = array_merge(
+    $batch['operations'],
+    $optionalDepsInstaller->installIfEnabled()
+  );
+
+  // Install modules and create demo content if eCommerce is enabled.
+  /** @var Drupal\presto\Installer\InstallerInterface $ecommerceInstaller */
   $ecommerceInstaller = Drupal::service('presto.installer.ecommerce');
   $ecommerceInstaller->setInstallState((array) $install_state);
-  // Install modules and create demo content if eCommerce is enabled.
   $batch['operations'] = array_merge(
     $batch['operations'],
     $ecommerceInstaller->installIfEnabled()

--- a/presto.services.yml
+++ b/presto.services.yml
@@ -1,4 +1,4 @@
 services:
-  plugin.manager.presto.ecommerce_demo_content:
-    class: Drupal\presto\Installer\Ecommerce\Content\Manager
+  plugin.manager.presto.demo_content:
+    class: Drupal\presto\Installer\Ecommerce\DemoContentManager
     parent: default_plugin_manager

--- a/presto.services.yml
+++ b/presto.services.yml
@@ -2,3 +2,7 @@ services:
   plugin.manager.presto.demo_content:
     class: Drupal\presto\Installer\Ecommerce\DemoContentManager
     parent: default_plugin_manager
+
+  presto.installer.ecommerce:
+    class: Drupal\presto\Installer\Ecommerce\EcommerceInstaller
+    arguments: ['@plugin.manager.presto.demo_content']

--- a/presto.services.yml
+++ b/presto.services.yml
@@ -1,6 +1,6 @@
 services:
   plugin.manager.presto.demo_content:
-    class: Drupal\presto\Installer\Ecommerce\DemoContentManager
+    class: Drupal\presto\Installer\DemoContentManager
     parent: default_plugin_manager
 
   presto.installer.ecommerce:

--- a/presto.services.yml
+++ b/presto.services.yml
@@ -3,6 +3,14 @@ services:
     class: Drupal\presto\Installer\DemoContentManager
     parent: default_plugin_manager
 
+  plugin.manager.presto.optional_dependencies:
+    class: Drupal\presto\Installer\OptionalDependencies\OptionalDependencyManager
+    parent: default_plugin_manager
+
+  presto.install.optional_dependencies:
+    class: Drupal\presto\Installer\OptionalDependencies\OptionalDependenciesInstaller
+    arguments: ['@plugin.manager.presto.optional_dependencies']
+
   presto.installer.ecommerce:
     class: Drupal\presto\Installer\Ecommerce\EcommerceInstaller
     arguments: ['@plugin.manager.presto.demo_content']

--- a/src/Annotation/PrestoDemoContent.php
+++ b/src/Annotation/PrestoDemoContent.php
@@ -11,7 +11,7 @@ use Drupal\Component\Annotation\Plugin;
  *
  * @Annotation
  */
-class PrestoEcommerceDemoContent extends Plugin {
+class PrestoDemoContent extends Plugin {
 
   /**
    * Plugin ID.
@@ -19,6 +19,13 @@ class PrestoEcommerceDemoContent extends Plugin {
    * @var string
    */
   public $id;
+
+  /**
+   * Plugin type (e.g. 'ecommerce').
+   *
+   * @var string
+   */
+  public $type;
 
   /**
    * The human-readable name of the plugin.

--- a/src/Annotation/PrestoOptionalDependency.php
+++ b/src/Annotation/PrestoOptionalDependency.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\presto\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a new Presto optional dependency.
+ *
+ * @package Drupal\presto\Annotation
+ *
+ * @Annotation
+ */
+class PrestoOptionalDependency extends Plugin {
+
+  /**
+   * Plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The weight of the plugin in relation to other plugins.
+   *
+   * @var int
+   */
+  public $weight = 0;
+
+}

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -134,6 +134,8 @@ class Package {
         unset($project['download']);
       }
     }
+    unset($project);
+
     file_put_contents('drupal-org.make', $encoder->encode($make));
   }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\presto;
+
+use InvalidArgumentException;
+
+/**
+ * Defines an enumeration base class.
+ *
+ * Based off commerceguys/enum, which we can't depend on as we need to be able
+ * to run the installer without any composer dependencies.
+ *
+ * @package Drupal\presto
+ */
+abstract class Enum {
+
+  /**
+   * Static flywheel cache of available values.
+   *
+   * @var array
+   */
+  protected static $values = [];
+
+  /**
+   * Enums can't be instantiated.
+   */
+  private function __construct() {
+  }
+
+  public static function getAll() {
+    $class = static::class;
+    if (!array_key_exists($class, static::$values)) {
+
+    }
+
+    return static::$values[$class];
+  }
+
+  /**
+   * Checks that a particular constant is defined.
+   *
+   * @param string $value
+   *   Constant name.
+   *
+   * @return bool
+   *   TRUE if the value is defined, FALSE otherwise.
+   */
+  public static function exists($value) {
+    return in_array($value, static::getAll(), true);
+  }
+
+  /**
+   * Asserts that a constant is defined.
+   *
+   * @param string $value
+   *   Constant name.
+   *
+   * @throws \InvalidArgumentException
+   *   If the value is not defined.
+   */
+  public static function assertExists($value) {
+    if (static::exists($value) === FALSE) {
+      throw new InvalidArgumentException("{$value} is not valid.");
+    }
+  }
+
+}

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -3,6 +3,7 @@
 namespace Drupal\presto;
 
 use InvalidArgumentException;
+use ReflectionClass;
 
 /**
  * Defines an enumeration base class.
@@ -21,16 +22,28 @@ abstract class Enum {
    */
   protected static $values = [];
 
+  // @codingStandardsIgnoreStart
   /**
    * Enums can't be instantiated.
    */
   private function __construct() {
+    // Do nothing.
   }
+  // @codingStandardsIgnoreEnd
 
+  /**
+   * Get all constants.
+   *
+   * @return array
+   *   Constant values, keyed by constant name.
+   *
+   * @throws \ReflectionException
+   */
   public static function getAll() {
     $class = static::class;
     if (!array_key_exists($class, static::$values)) {
-
+      $reflection = new ReflectionClass($class);
+      static::$values[$class] = $reflection->getConstants();
     }
 
     return static::$values[$class];
@@ -44,9 +57,11 @@ abstract class Enum {
    *
    * @return bool
    *   TRUE if the value is defined, FALSE otherwise.
+   *
+   * @throws \ReflectionException
    */
   public static function exists($value) {
-    return in_array($value, static::getAll(), true);
+    return in_array($value, static::getAll(), TRUE);
   }
 
   /**
@@ -57,6 +72,8 @@ abstract class Enum {
    *
    * @throws \InvalidArgumentException
    *   If the value is not defined.
+   *
+   * @throws \ReflectionException
    */
   public static function assertExists($value) {
     if (static::exists($value) === FALSE) {

--- a/src/Form/PrestoConfigureForm.php
+++ b/src/Form/PrestoConfigureForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Form;
+namespace Drupal\presto\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -8,7 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Defines a form that configures Presto's additional functionality.
  *
- * @package Drupal\presto\Installer\Form
+ * @package Drupal\presto\Form
  */
 class PrestoConfigureForm extends FormBase {
 

--- a/src/Form/PrestoConfigureForm.php
+++ b/src/Form/PrestoConfigureForm.php
@@ -37,6 +37,7 @@ class PrestoConfigureForm extends FormBase {
     // Only enable commerce if this profile was installed via Composer
     // (which is when the below interface will exist).
     $enableCommerce = FALSE;
+    /** @noinspection ClassConstantCanBeUsedInspection */
     if (interface_exists('CommerceGuys\Intl\Currency\CurrencyInterface')) {
       $enableCommerce = TRUE;
     }

--- a/src/Form/PrestoConfigureForm.php
+++ b/src/Form/PrestoConfigureForm.php
@@ -75,21 +75,19 @@ class PrestoConfigureForm extends FormBase {
 
     $form_state->set('optional_dependencies', []);
     foreach ($optionalDeps as $optionalDep) {
-      $pluginConfig = [];
-
       /** @var \Drupal\presto\Installer\OptionalDependencies\OptionalDependencyInterface $instance */
       $instance = $this->optionalDependencyManager->createInstance(
-        $optionalDep['id'],
-        $pluginConfig
+        $optionalDep['id']
       );
 
+      $pluginForm = [];
       $subFormState = SubformState::createForSubform(
-        $pluginConfig,
+        $pluginForm,
         $form,
         $form_state
       );
       $form['optional_dependencies'][$optionalDep['id']] = $instance->buildConfigurationForm(
-        $pluginConfig,
+        $pluginForm,
         $subFormState
       );
 

--- a/src/Form/PrestoConfigureForm.php
+++ b/src/Form/PrestoConfigureForm.php
@@ -96,6 +96,11 @@ class PrestoConfigureForm extends FormBase {
       $form_state->set(['optional_dependencies', $optionalDep['id']], $instance);
     }
 
+    // Hide optional dependencies fieldset if the config form is empty.
+    if (count(Element::children($form['optional_dependencies'])) === 0) {
+      $form['optional_dependencies']['#access'] = FALSE;
+    }
+
     $form['ecommerce'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('eCommerce'),

--- a/src/Installer/DemoContentInterface.php
+++ b/src/Installer/DemoContentInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\presto\Installer;
+
+/**
+ * Defines a new demo content item.
+ *
+ * @package Drupal\presto\Installer
+ */
+interface DemoContentInterface {
+
+  /**
+   * Creates a piece of demo content.
+   */
+  public function createContent();
+
+}

--- a/src/Installer/DemoContentManager.php
+++ b/src/Installer/DemoContentManager.php
@@ -6,7 +6,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\presto\Annotation\PrestoDemoContent;
-use Drupal\presto\Plugin\Presto\DemoContent\AbstractDemoContent;
 use Traversable;
 
 /**
@@ -36,7 +35,7 @@ class DemoContentManager extends DefaultPluginManager {
       'Plugin/Presto/DemoContent',
       $namespaces,
       $moduleHandler,
-      AbstractDemoContent::class,
+      DemoContentInterface::class,
       PrestoDemoContent::class
     );
 

--- a/src/Installer/DemoContentManager.php
+++ b/src/Installer/DemoContentManager.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\presto\Annotation\PrestoDemoContent;
+use Drupal\presto\Mixins\WeightedPluginManagerTrait;
 use Traversable;
 
 /**
@@ -14,6 +15,8 @@ use Traversable;
  * @package Drupal\presto\Installer
  */
 class DemoContentManager extends DefaultPluginManager {
+
+  use WeightedPluginManagerTrait;
 
   /**
    * Manager constructor.
@@ -51,16 +54,7 @@ class DemoContentManager extends DefaultPluginManager {
    */
   public function getDefinitions() {
     $definitions = parent::getDefinitions();
-
-    // Sort definitions by weight before returning.
-    uasort($definitions, function ($first, $second) {
-      if ($first['weight'] === $second['weight']) {
-        return 0;
-      }
-      return ($first['weight'] < $second['weight']) ? -1 : 1;
-    });
-
-    return $definitions;
+    return $this->sortByWeight($definitions);
   }
 
   /**

--- a/src/Installer/DemoContentManager.php
+++ b/src/Installer/DemoContentManager.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce;
+namespace Drupal\presto\Installer;
 
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
-use Drupal\presto\Annotation\PrestoEcommerceDemoContent;
+use Drupal\presto\Annotation\PrestoDemoContent;
 use Drupal\presto\Plugin\Presto\DemoContent\AbstractDemoContent;
+use Traversable;
 
 /**
- * Class Manager.
- *
  * Creates demo content using demo content creation plugins.
  *
- * @package Drupal\presto\Installer\Ecommerce
+ * @package Drupal\presto\Installer
  */
 class DemoContentManager extends DefaultPluginManager {
 
@@ -29,7 +28,7 @@ class DemoContentManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(
-    \Traversable $namespaces,
+    Traversable $namespaces,
     CacheBackendInterface $cacheBackend,
     ModuleHandlerInterface $moduleHandler
   ) {
@@ -38,7 +37,7 @@ class DemoContentManager extends DefaultPluginManager {
       $namespaces,
       $moduleHandler,
       AbstractDemoContent::class,
-      PrestoEcommerceDemoContent::class
+      PrestoDemoContent::class
     );
 
     $this->alterInfo('presto_ecommerce_demo_content_info');
@@ -63,6 +62,23 @@ class DemoContentManager extends DefaultPluginManager {
     });
 
     return $definitions;
+  }
+
+  /**
+   * Filters plugin definitions by a type.
+   *
+   * @param string $type
+   *   Type to filter by.
+   *
+   * @return array
+   *   A list of filtered plugin definitions.
+   */
+  public function getFilteredDefinitions($type) {
+    $all = $this->getDefinitions();
+
+    return array_filter($all, function ($definition) use ($type) {
+      return $definition['type'] === $type;
+    });
   }
 
 }

--- a/src/Installer/DemoContentTypes.php
+++ b/src/Installer/DemoContentTypes.php
@@ -2,12 +2,14 @@
 
 namespace Drupal\presto\Installer;
 
+use Drupal\presto\Enum;
+
 /**
  * Defines a set of demo content types.
  *
  * @package Drupal\presto\Installer
  */
-final class DemoContentTypes {
+final class DemoContentTypes extends Enum {
 
   const ECOMMERCE = 'ecommerce';
 

--- a/src/Installer/DemoContentTypes.php
+++ b/src/Installer/DemoContentTypes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\presto\Installer;
+
+/**
+ * Defines a set of demo content types.
+ *
+ * @package Drupal\presto\Installer
+ */
+final class DemoContentTypes {
+
+  const ECOMMERCE = 'ecommerce';
+
+}

--- a/src/Installer/DependencyTypes.php
+++ b/src/Installer/DependencyTypes.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\presto\Installer;
+
+use Drupal\presto\Enum;
+
+/**
+ * Defines dependency types.
+ *
+ * @package Drupal\presto\Installer
+ */
+final class DependencyTypes extends Enum {
+
+  const THEME = 'theme';
+
+  const MODULE = 'module';
+
+}

--- a/src/Installer/Ecommerce/DemoContentManager.php
+++ b/src/Installer/Ecommerce/DemoContentManager.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content;
+namespace Drupal\presto\Installer\Ecommerce;
 
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\presto\Annotation\PrestoEcommerceDemoContent;
-use Drupal\presto\Installer\Ecommerce\Content\Plugin\AbstractDemoContent;
+use Drupal\presto\Plugin\Presto\DemoContent\AbstractDemoContent;
 
 /**
  * Class Manager.
  *
  * Creates demo content using demo content creation plugins.
  *
- * @package Drupal\presto\Installer\Ecommerce\Content
+ * @package Drupal\presto\Installer\Ecommerce
  */
-class Manager extends DefaultPluginManager {
+class DemoContentManager extends DefaultPluginManager {
 
   /**
    * Manager constructor.
@@ -34,7 +34,7 @@ class Manager extends DefaultPluginManager {
     ModuleHandlerInterface $moduleHandler
   ) {
     parent::__construct(
-      'Installer/Ecommerce/Content/Plugin',
+      'Plugin/Presto/DemoContent',
       $namespaces,
       $moduleHandler,
       AbstractDemoContent::class,

--- a/src/Installer/Ecommerce/EcommerceInstaller.php
+++ b/src/Installer/Ecommerce/EcommerceInstaller.php
@@ -5,8 +5,9 @@ namespace Drupal\presto\Installer\Ecommerce;
 use Drupal;
 use Drupal\presto\Installer\DemoContentManager;
 use Drupal\presto\Installer\DemoContentTypes;
-use Drupal\presto\Installer\InstallerException;
+use Drupal\presto\Installer\DependencyTypes;
 use Drupal\presto\Installer\InstallerInterface;
+use Drupal\presto\Mixins\DrupalDependencyInstallerTrait;
 
 /**
  * Presto eCommerce module + content installer.
@@ -15,8 +16,7 @@ use Drupal\presto\Installer\InstallerInterface;
  */
 class EcommerceInstaller implements InstallerInterface {
 
-  const DEPENDENCY_TYPE_MODULE = 'module';
-  const DEPENDENCY_TYPE_THEME = 'theme';
+  use DrupalDependencyInstallerTrait;
 
   /**
    * All eCommerce dependencies.
@@ -24,19 +24,19 @@ class EcommerceInstaller implements InstallerInterface {
    * @var array
    */
   private $dependencies = [
-    'commerce' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_order' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_price' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_product' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_cart' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_checkout' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_payment' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_payment_example' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_promotion' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_tax' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_log' => self::DEPENDENCY_TYPE_MODULE,
-    'physical' => self::DEPENDENCY_TYPE_MODULE,
-    'commerce_shipping' => self::DEPENDENCY_TYPE_MODULE,
+    'commerce' => DependencyTypes::MODULE,
+    'commerce_order' => DependencyTypes::MODULE,
+    'commerce_price' => DependencyTypes::MODULE,
+    'commerce_product' => DependencyTypes::MODULE,
+    'commerce_cart' => DependencyTypes::MODULE,
+    'commerce_checkout' => DependencyTypes::MODULE,
+    'commerce_payment' => DependencyTypes::MODULE,
+    'commerce_payment_example' => DependencyTypes::MODULE,
+    'commerce_promotion' => DependencyTypes::MODULE,
+    'commerce_tax' => DependencyTypes::MODULE,
+    'commerce_log' => DependencyTypes::MODULE,
+    'physical' => DependencyTypes::MODULE,
+    'commerce_shipping' => DependencyTypes::MODULE,
   ];
 
   /**
@@ -162,7 +162,7 @@ class EcommerceInstaller implements InstallerInterface {
       [static::class, 'installDependency'],
       [
         'presto_commerce',
-        static::DEPENDENCY_TYPE_MODULE,
+        DependencyTypes::MODULE,
       ],
     ];
 
@@ -175,57 +175,6 @@ class EcommerceInstaller implements InstallerInterface {
     }
 
     return $operations;
-  }
-
-  /**
-   * Installs a Drupal dependency (e.g. a module or a theme).
-   *
-   * This is a Drupal batch callback operation and as such, needs to be both a
-   * public and a static function so that the Batch API can access it outside
-   * the context of this class.
-   *
-   * @param string $dependency
-   *   Dependency machine name.
-   * @param string $type
-   *   Dependency type.
-   * @param array $context
-   *   Batch context.
-   *
-   * @throws Drupal\Core\Extension\ExtensionNameLengthException
-   * @throws Drupal\Core\Extension\MissingDependencyException
-   * @throws \Drupal\presto\Installer\InstallerException
-   */
-  public static function installDependency($dependency, $type, array &$context) {
-    // Reset time limit so we don't timeout.
-    drupal_set_time_limit(0);
-
-    switch ($type) {
-      case static::DEPENDENCY_TYPE_MODULE:
-        /** @var \Drupal\Core\Extension\ModuleInstaller $moduleInstaller */
-        $moduleInstaller = Drupal::service('module_installer');
-        $moduleInstaller->install([$dependency]);
-        break;
-
-      case static::DEPENDENCY_TYPE_THEME:
-        /** @var \Drupal\Core\Extension\ThemeInstaller $themeInstaller */
-        $themeInstaller = Drupal::service('theme_installer');
-        $themeInstaller->install([$dependency]);
-        break;
-
-      default:
-        throw new InstallerException(
-          "Unknown dependency type '{$type}'."
-        );
-    }
-
-    $context['results'][] = $dependency;
-    $context['message'] = t(
-      'Installed @dependency_type %dependency.',
-      [
-        '@dependency_type' => $type,
-        '%dependency' => $dependency,
-      ]
-    );
   }
 
   /**

--- a/src/Installer/Ecommerce/EcommerceInstaller.php
+++ b/src/Installer/Ecommerce/EcommerceInstaller.php
@@ -3,6 +3,7 @@
 namespace Drupal\presto\Installer\Ecommerce;
 
 use Drupal;
+use Drupal\presto\Installer\DemoContentTypes;
 use Drupal\presto\Installer\InstallerException;
 use Drupal\presto\Installer\InstallerInterface;
 
@@ -47,14 +48,14 @@ class EcommerceInstaller implements InstallerInterface {
   /**
    * The demo content creation manager.
    *
-   * @var \Drupal\presto\Installer\Ecommerce\DemoContentManager
+   * @var \Drupal\presto\Installer\DemoContentManager
    */
   private $demoContentManager;
 
   /**
    * PrestoEcommerceInstaller constructor.
    *
-   * @param \Drupal\presto\Installer\Ecommerce\DemoContentManager $manager
+   * @param \Drupal\presto\Installer\DemoContentManager $manager
    *   The demo content creation manager.
    * @param array $installState
    *   Current install state.
@@ -151,7 +152,9 @@ class EcommerceInstaller implements InstallerInterface {
   private function addDemoContentOperations() {
     $operations = [];
 
-    $contentDefs = $this->demoContentManager->getDefinitions();
+    $contentDefs = $this->demoContentManager->getFilteredDefinitions(
+      DemoContentTypes::ECOMMERCE
+    );
 
     // Add module install task to install our commerce exports module.
     $operations[] = [
@@ -243,7 +246,7 @@ class EcommerceInstaller implements InstallerInterface {
     drupal_set_time_limit(0);
 
     // Needs to be resolved manually since we don't have a context.
-    /** @var \Drupal\presto\Installer\Ecommerce\DemoContentManager $demoContentManager */
+    /** @var \Drupal\presto\Installer\DemoContentManager $demoContentManager */
     $demoContentManager = Drupal::service(
       'plugin.manager.presto.demo_content'
     );

--- a/src/Installer/Ecommerce/EcommerceInstaller.php
+++ b/src/Installer/Ecommerce/EcommerceInstaller.php
@@ -3,6 +3,7 @@
 namespace Drupal\presto\Installer\Ecommerce;
 
 use Drupal;
+use Drupal\presto\Installer\DemoContentManager;
 use Drupal\presto\Installer\DemoContentTypes;
 use Drupal\presto\Installer\InstallerException;
 use Drupal\presto\Installer\InstallerInterface;

--- a/src/Installer/Ecommerce/Installer.php
+++ b/src/Installer/Ecommerce/Installer.php
@@ -3,14 +3,14 @@
 namespace Drupal\presto\Installer\Ecommerce;
 
 use Drupal;
-use Drupal\presto\Installer\Ecommerce\Content\Manager as DemoContentManager;
+use Drupal\presto\Installer\InstallerInterface;
 
 /**
  * Presto eCommerce module + content installer.
  *
  * @package Drupal\presto\Installer\Ecommerce
  */
-class Installer {
+class Installer implements InstallerInterface {
 
   const DEPENDENCY_TYPE_MODULE = 'module';
   const DEPENDENCY_TYPE_THEME = 'theme';
@@ -76,16 +76,13 @@ class Installer {
    */
   public static function create(array $installState) {
     $demoContentManager = Drupal::service(
-      'plugin.manager.presto.ecommerce_demo_content'
+      'plugin.manager.presto.demo_content'
     );
     return new static($installState, $demoContentManager);
   }
 
   /**
-   * Sets up all install tasks if they're enabled.
-   *
-   * @return array
-   *   A batch operations definition with all enabled install tasks.
+   * {@inheritdoc}
    */
   public function installIfEnabled() {
     $operations = [];
@@ -202,13 +199,13 @@ class Installer {
       case static::DEPENDENCY_TYPE_MODULE:
         /** @var \Drupal\Core\Extension\ModuleInstaller $moduleInstaller */
         $moduleInstaller = Drupal::service('module_installer');
-        $moduleInstaller->install([$dependency], TRUE);
+        $moduleInstaller->install([$dependency]);
         break;
 
       case static::DEPENDENCY_TYPE_THEME:
         /** @var \Drupal\Core\Extension\ThemeInstaller $themeInstaller */
         $themeInstaller = Drupal::service('theme_installer');
-        $themeInstaller->install([$dependency], TRUE);
+        $themeInstaller->install([$dependency]);
         break;
 
       default:

--- a/src/Installer/Ecommerce/Installer.php
+++ b/src/Installer/Ecommerce/Installer.php
@@ -46,7 +46,7 @@ class Installer {
   /**
    * The demo content creation manager.
    *
-   * @var \Drupal\presto\Installer\Ecommerce\Content\Manager
+   * @var \Drupal\presto\Installer\Ecommerce\DemoContentManager
    */
   private $demoContentManager;
 
@@ -55,7 +55,7 @@ class Installer {
    *
    * @param array $installState
    *   Current install state.
-   * @param \Drupal\presto\Installer\Ecommerce\Content\Manager $manager
+   * @param \Drupal\presto\Installer\Ecommerce\DemoContentManager $manager
    *   The demo content creation manager.
    */
   public function __construct(
@@ -246,16 +246,16 @@ class Installer {
     drupal_set_time_limit(0);
 
     // Needs to be resolved manually since we don't have a context.
-    /** @var \Drupal\presto\Installer\Ecommerce\Content\Manager $demoContentManager */
+    /** @var \Drupal\presto\Installer\Ecommerce\DemoContentManager $demoContentManager */
     $demoContentManager = Drupal::service(
-      'plugin.manager.presto.ecommerce_demo_content'
+      'plugin.manager.presto.demo_content'
     );
 
     $definition = $demoContentManager->getDefinition($pluginId);
     /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $label */
     $label = $definition['label'];
 
-    /** @var \Drupal\presto\Installer\Ecommerce\Content\Plugin\AbstractDemoContent $instance */
+    /** @var \Drupal\presto\Plugin\Presto\DemoContent\AbstractDemoContent $instance */
     $instance = $demoContentManager->createInstance($pluginId);
     $instance->createContent();
 

--- a/src/Installer/InstallerException.php
+++ b/src/Installer/InstallerException.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce;
+namespace Drupal\presto\Installer;
 
 use Exception;
 
 /**
  * Thrown if the installer fails.
  *
- * @package Drupal\presto\Installer\Ecommerce
+ * @package Drupal\presto\Installer
  */
 class InstallerException extends Exception {
 }

--- a/src/Installer/InstallerInterface.php
+++ b/src/Installer/InstallerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\presto\Installer;
+
+/**
+ * Interface InstallerInterface.
+ *
+ * @package Drupal\presto\Installer
+ */
+interface InstallerInterface {
+
+  /**
+   * Sets up all install tasks if they're enabled.
+   *
+   * @return array
+   *   A batch operations definition with all enabled install tasks.
+   */
+  public function installIfEnabled();
+
+}

--- a/src/Installer/InstallerInterface.php
+++ b/src/Installer/InstallerInterface.php
@@ -10,6 +10,16 @@ namespace Drupal\presto\Installer;
 interface InstallerInterface {
 
   /**
+   * Set current Drupal install state.
+   *
+   * @param array $installState
+   *   Install state to set.
+   *
+   * @return $this
+   */
+  public function setInstallState(array $installState);
+
+  /**
    * Sets up all install tasks if they're enabled.
    *
    * @return array

--- a/src/Installer/InstallerInterface.php
+++ b/src/Installer/InstallerInterface.php
@@ -24,6 +24,8 @@ interface InstallerInterface {
    *
    * @return array
    *   A batch operations definition with all enabled install tasks.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function installIfEnabled();
 

--- a/src/Installer/OptionalDependencies/OptionalDependenciesInstaller.php
+++ b/src/Installer/OptionalDependencies/OptionalDependenciesInstaller.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\presto\Installer\OptionalDependencies;
+
+use Drupal\presto\Installer\InstallerInterface;
+
+/**
+ * Installs optional dependencies.
+ *
+ * @package Drupal\presto\Installer\OptionalDependencies
+ */
+class OptionalDependenciesInstaller implements InstallerInterface {
+
+  // Key in the install state that optional dependency config is stored in.
+  const CONFIG_KEY = 'optional_dependencies';
+
+  /**
+   * The Drupal install state.
+   *
+   * @var array
+   */
+  private $installState;
+
+  /**
+   * The optional dependency manager.
+   *
+   * @var \Drupal\presto\Installer\OptionalDependencies\OptionalDependencyManager
+   */
+  private $optionalDependencyManager;
+
+  /**
+   * OptionalDependenciesInstaller constructor.
+   *
+   * @param \Drupal\presto\Installer\OptionalDependencies\OptionalDependencyManager $manager
+   *   The optional dependency manager.
+   * @param array $installState
+   *   The Drupal install state.
+   */
+  public function __construct(
+    OptionalDependencyManager $manager,
+    array $installState = []
+  ) {
+    $this->optionalDependencyManager = $manager;
+    $this->installState = $installState;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setInstallState(array $installState) {
+    $this->installState = $installState;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function installIfEnabled() {
+    $operations = [];
+
+    $dependencies = $this->optionalDependencyManager->getDefinitions();
+
+    foreach ($dependencies as $dependency) {
+      /** @var \Drupal\presto\Installer\OptionalDependencies\OptionalDependencyInterface $instance */
+      $instance = $this->optionalDependencyManager->createInstance(
+        $dependency['id'],
+        $this->getPluginConfig($dependency['id'])
+      );
+
+      if ($instance->shouldInstall($this->installState)) {
+        $operations[] = $instance->getInstallOperations();
+      }
+    }
+
+    // Prevent a greedy array_merge (argument unpacking not used for PHP 5.5
+    // support).
+    if (count($operations) > 0) {
+      /** @noinspection ArgumentUnpackingCanBeUsedInspection */
+      $operations = call_user_func_array('array_merge', $operations);
+    }
+
+    return $operations;
+  }
+
+  /**
+   * Get plugin config from the install state.
+   *
+   * @param string $pluginId
+   *   Plugin ID.
+   *
+   * @return array
+   *   Plugin config (if any).
+   */
+  private function getPluginConfig($pluginId) {
+    if (!array_key_exists(static::CONFIG_KEY, $this->installState)) {
+      return [];
+    }
+
+    if (!array_key_exists($pluginId, $this->installState[static::CONFIG_KEY])) {
+      return [];
+    }
+
+    return $this->installState[static::CONFIG_KEY][$pluginId];
+  }
+
+}

--- a/src/Installer/OptionalDependencies/OptionalDependencyInterface.php
+++ b/src/Installer/OptionalDependencies/OptionalDependencyInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\presto\Installer\OptionalDependencies;
+
+use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+
+/**
+ * Defines a new optional dependency.
+ *
+ * @package Drupal\presto\Installer\OptionalDependencies
+ */
+interface OptionalDependencyInterface extends
+    PluginFormInterface,
+    ConfigurablePluginInterface {
+
+  /**
+   * Checks if this dependency should be installed.
+   *
+   * @param array $installState
+   *   The current Drupal install state.
+   *
+   * @return bool
+   *   TRUE if this dependency should be installed, FALSE otherwise.
+   */
+  public function shouldInstall(array $installState);
+
+  /**
+   * Get any required Batch API install operations for this dependency.
+   *
+   * @return array
+   *   Batch operation definitions.
+   */
+  public function getInstallOperations();
+
+}

--- a/src/Installer/OptionalDependencies/OptionalDependencyManager.php
+++ b/src/Installer/OptionalDependencies/OptionalDependencyManager.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\presto\Installer\OptionalDependencies;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\presto\Annotation\PrestoOptionalDependency;
+use Drupal\presto\Mixins\WeightedPluginManagerTrait;
+use Traversable;
+
+/**
+ * Class OptionalDependenciesManager.
+ *
+ * @package Drupal\presto\Installer\OptionalDependencies
+ */
+class OptionalDependencyManager extends DefaultPluginManager {
+
+  use WeightedPluginManagerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    Traversable $namespaces,
+    CacheBackendInterface $cacheBackend,
+    ModuleHandlerInterface $moduleHandler
+  ) {
+    parent::__construct(
+      'Plugin/Presto/OptionalDependency',
+      $namespaces,
+      $moduleHandler,
+      OptionalDependencyInterface::class,
+      PrestoOptionalDependency::class
+    );
+
+    $this->alterInfo('presto_ecommerce_optional_dependency_info');
+    $this->setCacheBackend(
+      $cacheBackend,
+      'presto_ecommerce_optional_dependency'
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinitions() {
+    $definitions = parent::getDefinitions();
+    return $this->sortByWeight($definitions);
+  }
+
+}

--- a/src/Mixins/DrupalDependencyInstallerTrait.php
+++ b/src/Mixins/DrupalDependencyInstallerTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\presto\Mixins;
+
+use Drupal;
+use Drupal\presto\Installer\DependencyTypes;
+use Drupal\presto\Installer\InstallerException;
+
+/**
+ * Adds helpers to handle module/theme installs in a Batch API context.
+ *
+ * @package Drupal\presto\Mixins
+ */
+trait DrupalDependencyInstallerTrait {
+
+  /**
+   * Installs a Drupal dependency (e.g. a module or a theme).
+   *
+   * This is a Drupal batch callback operation and as such, needs to be both a
+   * public and a static function so that the Batch API can access it outside
+   * the context of this class.
+   *
+   * @param string $dependency
+   *   Dependency machine name.
+   * @param string $type
+   *   Dependency type.
+   * @param array $context
+   *   Batch API context.
+   *
+   * @throws \Drupal\Core\Extension\ExtensionNameLengthException
+   * @throws \Drupal\Core\Extension\MissingDependencyException
+   * @throws \Drupal\presto\Installer\InstallerException
+   */
+  public static function installDependency($dependency, $type, array &$context) {
+    // Reset time limit so we don't timeout.
+    drupal_set_time_limit(0);
+
+    switch ($type) {
+      case DependencyTypes::MODULE:
+        /** @var \Drupal\Core\Extension\ModuleInstaller $moduleInstaller */
+        $moduleInstaller = Drupal::service('module_installer');
+        $moduleInstaller->install([$dependency]);
+        break;
+
+      case DependencyTypes::THEME:
+        /** @var \Drupal\Core\Extension\ThemeInstaller $themeInstaller */
+        $themeInstaller = Drupal::service('theme_installer');
+        $themeInstaller->install([$dependency]);
+        break;
+
+      default:
+        throw new InstallerException(
+          "Unknown dependency type '{$type}'."
+        );
+    }
+
+    $context['results'][] = $dependency;
+    $context['message'] = t(
+      'Installed @dependency_type %dependency.',
+      [
+        '@dependency_type' => $type,
+        '%dependency' => $dependency,
+      ]
+    );
+  }
+
+}

--- a/src/Mixins/WeightedPluginManagerTrait.php
+++ b/src/Mixins/WeightedPluginManagerTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\presto\Mixins;
+
+/**
+ * Adds definition sorting (by weight) to plugin managers.
+ *
+ * @package Drupal\presto\Mixins
+ */
+trait WeightedPluginManagerTrait {
+
+  /**
+   * Sorts plugins by weight.
+   *
+   * @param array $definitions
+   *   List of plugin definitions, each MUST have a 'weight' key.
+   *
+   * @return array
+   *   Sorted definitions.
+   */
+  protected function sortByWeight(array $definitions) {
+    // Sort definitions by weight before returning.
+    uasort($definitions, function ($first, $second) {
+      if ($first['weight'] === $second['weight']) {
+        return 0;
+      }
+      return ($first['weight'] < $second['weight']) ? -1 : 1;
+    });
+
+    return $definitions;
+  }
+
+}

--- a/src/Plugin/Presto/DemoContent/AbstractBaseProductCreator.php
+++ b/src/Plugin/Presto/DemoContent/AbstractBaseProductCreator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal;
 use Drupal\commerce_product\Entity\Product;
@@ -10,7 +10,7 @@ use Drupal\commerce_product\Entity\ProductVariation;
 /**
  * Base class for all product creating classes.
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 abstract class AbstractBaseProductCreator extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/AbstractDemoContent.php
+++ b/src/Plugin/Presto/DemoContent/AbstractDemoContent.php
@@ -6,6 +6,7 @@ use Drupal;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
+use Drupal\presto\Installer\DemoContentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -16,7 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 abstract class AbstractDemoContent extends PluginBase implements
-    ContainerFactoryPluginInterface {
+    ContainerFactoryPluginInterface,
+    DemoContentInterface {
 
   /**
    * Entity manager.
@@ -90,10 +92,5 @@ abstract class AbstractDemoContent extends PluginBase implements
 
     return $storeId;
   }
-
-  /**
-   * Creates a piece of demo content.
-   */
-  abstract public function createContent();
 
 }

--- a/src/Plugin/Presto/DemoContent/AbstractDemoContent.php
+++ b/src/Plugin/Presto/DemoContent/AbstractDemoContent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * Sets up base functionality for demo content creation plugins.
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 abstract class AbstractDemoContent extends PluginBase implements
     ContainerFactoryPluginInterface {
@@ -50,6 +50,9 @@ abstract class AbstractDemoContent extends PluginBase implements
 
   /**
    * {@inheritdoc}
+   *
+   * @throws \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
+   * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
    */
   public static function create(
     ContainerInterface $container,

--- a/src/Plugin/Presto/DemoContent/CreateEbookProduct.php
+++ b/src/Plugin/Presto/DemoContent/CreateEbookProduct.php
@@ -5,8 +5,9 @@ namespace Drupal\presto\Plugin\Presto\DemoContent;
 /**
  * Creates the demo Drupal Commerce store.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "create_ebook_product",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create eBook product"),
  *     weight = 6
  * )

--- a/src/Plugin/Presto/DemoContent/CreateEbookProduct.php
+++ b/src/Plugin/Presto/DemoContent/CreateEbookProduct.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 /**
  * Creates the demo Drupal Commerce store.
@@ -11,7 +11,7 @@ namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
  *     weight = 6
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreateEbookProduct extends AbstractBaseProductCreator {
 

--- a/src/Plugin/Presto/DemoContent/CreateFlatRateShippingMethod.php
+++ b/src/Plugin/Presto/DemoContent/CreateFlatRateShippingMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal\commerce_shipping\Entity\ShippingMethod;
 
@@ -13,7 +13,7 @@ use Drupal\commerce_shipping\Entity\ShippingMethod;
  *     weight = 7
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreateFlatRateShippingMethod extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/CreateFlatRateShippingMethod.php
+++ b/src/Plugin/Presto/DemoContent/CreateFlatRateShippingMethod.php
@@ -7,8 +7,9 @@ use Drupal\commerce_shipping\Entity\ShippingMethod;
 /**
  * Creates the 'flat rate' shipment method.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "create_flat_rate_shipment_method",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create Flat Rate shipment method"),
  *     weight = 7
  * )

--- a/src/Plugin/Presto/DemoContent/CreatePhysicalBookProduct.php
+++ b/src/Plugin/Presto/DemoContent/CreatePhysicalBookProduct.php
@@ -5,8 +5,9 @@ namespace Drupal\presto\Plugin\Presto\DemoContent;
 /**
  * Creates the demo Drupal Commerce store.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "create_physical_book_product",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create physical book product"),
  *     weight = 5
  * )

--- a/src/Plugin/Presto/DemoContent/CreatePhysicalBookProduct.php
+++ b/src/Plugin/Presto/DemoContent/CreatePhysicalBookProduct.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 /**
  * Creates the demo Drupal Commerce store.
@@ -11,7 +11,7 @@ namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
  *     weight = 5
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreatePhysicalBookProduct extends AbstractBaseProductCreator {
 

--- a/src/Plugin/Presto/DemoContent/CreateProductAttributeValues.php
+++ b/src/Plugin/Presto/DemoContent/CreateProductAttributeValues.php
@@ -7,8 +7,9 @@ use Drupal\commerce_product\Entity\ProductAttributeValue;
 /**
  * Creates a set of demo product attribute values.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "product_attribute_values",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create Drupal Commerce product attribute values"),
  *     weight = 2
  * )

--- a/src/Plugin/Presto/DemoContent/CreateProductAttributeValues.php
+++ b/src/Plugin/Presto/DemoContent/CreateProductAttributeValues.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal\commerce_product\Entity\ProductAttributeValue;
 
@@ -13,7 +13,7 @@ use Drupal\commerce_product\Entity\ProductAttributeValue;
  *     weight = 2
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreateProductAttributeValues extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/CreateProductListingPage.php
+++ b/src/Plugin/Presto/DemoContent/CreateProductListingPage.php
@@ -9,8 +9,9 @@ use Drupal\node\Entity\Node;
 /**
  * Creates the product listing page.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "create_product_listing",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create product listing page"),
  *     weight = 10
  * )

--- a/src/Plugin/Presto/DemoContent/CreateProductListingPage.php
+++ b/src/Plugin/Presto/DemoContent/CreateProductListingPage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
@@ -15,7 +15,7 @@ use Drupal\node\Entity\Node;
  *     weight = 10
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreateProductListingPage extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/CreateStore.php
+++ b/src/Plugin/Presto/DemoContent/CreateStore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal;
 use Drupal\commerce_store\Entity\Store;
@@ -14,7 +14,7 @@ use Drupal\commerce_store\Entity\Store;
  *     weight = 1
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class CreateStore extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/CreateStore.php
+++ b/src/Plugin/Presto/DemoContent/CreateStore.php
@@ -8,8 +8,9 @@ use Drupal\commerce_store\Entity\Store;
 /**
  * Creates the demo Drupal Commerce store.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "store",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Create Drupal Commerce demo store"),
  *     weight = 1
  * )

--- a/src/Plugin/Presto/DemoContent/RemoveDefaultProductTypes.php
+++ b/src/Plugin/Presto/DemoContent/RemoveDefaultProductTypes.php
@@ -8,8 +8,9 @@ use Drupal\commerce_product\Entity\ProductVariationType;
 /**
  * Removes the default product types as we create our own.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "remove_default_products",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Remove default product types"),
  *     weight = 0
  * )

--- a/src/Plugin/Presto/DemoContent/RemoveDefaultProductTypes.php
+++ b/src/Plugin/Presto/DemoContent/RemoveDefaultProductTypes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal\commerce_product\Entity\ProductType;
 use Drupal\commerce_product\Entity\ProductVariationType;
@@ -14,7 +14,7 @@ use Drupal\commerce_product\Entity\ProductVariationType;
  *     weight = 0
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class RemoveDefaultProductTypes extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/DemoContent/SetupCheckoutFlow.php
+++ b/src/Plugin/Presto/DemoContent/SetupCheckoutFlow.php
@@ -8,8 +8,9 @@ use Drupal\Core\Config\FileStorage;
 /**
  * Sets up the checkout flow.
  *
- * @PrestoEcommerceDemoContent(
+ * @PrestoDemoContent(
  *     id = "setup_checkout_flow",
+ *     type = \Drupal\presto\Installer\DemoContentTypes::ECOMMERCE,
  *     label = @Translation("Setup checkout flow"),
  *     weight = 4
  * )

--- a/src/Plugin/Presto/DemoContent/SetupCheckoutFlow.php
+++ b/src/Plugin/Presto/DemoContent/SetupCheckoutFlow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\presto\Installer\Ecommerce\Content\Plugin;
+namespace Drupal\presto\Plugin\Presto\DemoContent;
 
 use Drupal;
 use Drupal\Core\Config\FileStorage;
@@ -14,7 +14,7 @@ use Drupal\Core\Config\FileStorage;
  *     weight = 4
  * )
  *
- * @package Drupal\presto\Installer\Ecommerce\Content\Plugin
+ * @package Drupal\presto\Plugin\Presto\DemoContent
  */
 class SetupCheckoutFlow extends AbstractDemoContent {
 

--- a/src/Plugin/Presto/OptionalDependency/AbstractOptionalDependency.php
+++ b/src/Plugin/Presto/OptionalDependency/AbstractOptionalDependency.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\presto\Plugin\Presto\OptionalDependency;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\presto\Installer\OptionalDependencies\OptionalDependencyInterface;
+use Drupal\presto\Mixins\DrupalDependencyInstallerTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class AbstractOptionalDependency.
+ *
+ * @package Drupal\presto\Plugin\OptionalDependency
+ */
+abstract class AbstractOptionalDependency extends PluginBase implements
+    ContainerFactoryPluginInterface,
+    OptionalDependencyInterface {
+
+  use DrupalDependencyInstallerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $pluginId,
+    $pluginDefinition
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->configuration += $this->defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $pluginId,
+    $pluginDefinition
+  ) {
+    return new static(
+      $configuration,
+      $pluginId,
+      $pluginDefinition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->configuration = $configuration;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    // Validation is optional.
+  }
+
+}

--- a/src/Plugin/Presto/OptionalDependency/InstallSwiftmailer.php
+++ b/src/Plugin/Presto/OptionalDependency/InstallSwiftmailer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\presto\Plugin\Presto\OptionalDependency;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\presto\Installer\DependencyTypes;
+
+/**
+ * Installs swiftmailer if possible.
+ *
+ * @PrestoOptionalDependency(
+ *     id = "install_swiftmailer",
+ *     label = @Translation("Install SwiftMailer"),
+ *     weight = 0
+ * )
+ */
+class InstallSwiftmailer extends AbstractOptionalDependency {
+
+  // The swiftmailer module machine name.
+  const MODULE_NAME = 'swiftmailer';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldInstall(array $installState) {
+    // Only install this if the swiftmailer library exist. It may not if this
+    // profile was downloaded from drupal.org.
+    /** @noinspection ClassConstantCanBeUsedInspection */
+    return class_exists('\Swift_Mailer');
+  }
+
+  /**
+   * Get any required Batch API install operations for this dependency.
+   *
+   * @return array
+   *   Batch operation definitions.
+   */
+  public function getInstallOperations() {
+    return [
+      [
+        [static::class, 'installDependency'],
+        [
+          static::MODULE_NAME,
+          DependencyTypes::MODULE,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    // This dependency has no configuration.
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(
+    array $form,
+    FormStateInterface $form_state
+  ) {
+    // No configuration required for this dependency.
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    // Nothing to do, we don't have a form.
+  }
+
+}


### PR DESCRIPTION
This fixes #116 

Test scenarios:
* Test install flow with (the `swiftmail` module should be installed):
  * eCommerce disabled
  * eCommerce enabled
* After running `composer update`, manually remove the `vendor/swiftmailer` folder, it **shouldn't** install the `swiftmail` module